### PR TITLE
Add Rbmap and TPCC

### DIFF
--- a/src/irbmap.ml
+++ b/src/irbmap.ml
@@ -1,0 +1,22 @@
+module Make(Key : Content.ATOM)(Value: Content.TYPE)(S: System.T):
+  Content.TYPE with type o = Mrbmap.Make(Key)(Value).t = struct
+
+  module Map = Mrbmap.Make(Key)(Value)
+
+  module T = struct
+    type t = Map.t
+    let t = Map.t
+  end
+
+  module CStore = ContentStore.Make(T)
+
+  include T
+
+  type o = t
+
+  let o_merge = Map.merge
+
+  let to_adt t = t
+  let of_adt t = t
+  let merge = o_merge
+end

--- a/src/mrbmap.ml
+++ b/src/mrbmap.ml
@@ -1,0 +1,337 @@
+(* Modified from code under following license:
+ * 
+ * Copyright (c) 2007, Benedikt Meurer <benedikt.meurer@googlemail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *)
+
+module Make (Key : Content.ATOM)(Value : Content.TYPE) = struct
+  type key = Key.t
+  type value = Value.t
+
+  type t =
+    | Black of t * (Key.t * Value.t) * t
+    | Red of t * (Key.t * Value.t) * t
+    | Empty
+  [@@deriving irmin]
+
+  type enum =
+    | End
+    | More of key * value * t * enum
+
+  let rec enum m e =
+    match m with
+      | Empty -> e
+      | Black(l, (k, x), r) | Red(l, (k, x), r) -> enum l (More(k, x, r, e))
+
+  let rec keys = function
+    | Empty -> []
+    | Black(l, (k, _), r) | Red(l, (k, _), r) -> keys l @ (k :: keys r)
+
+  let blackify = function
+    | Red(l, (k, x), r) -> Black(l, (k, x), r), false
+    | m -> m, true
+
+  let empty = Empty
+
+  let is_empty = function
+    | Empty -> true
+    | _ -> false
+
+  let balance_left l kx x r =
+    match l, kx, x, r with
+      | Red(Red(a, (kx, x), b), (ky, y), c), kz, z, d
+      | Red(a, (kx, x), Red(b, (ky, y), c)), kz, z, d ->
+          Red(Black(a, (kx, x), b), (ky, y), Black(c, (kz, z), d))
+      | l, kx, x, r ->
+          Black(l, (kx, x), r)
+
+  let balance_right l kx x r =
+    match l, kx, x, r with
+      | a, kx, x, Red(Red(b, (ky, y), c), (kz, z), d)
+      | a, kx, x, Red(b, (ky, y), Red(c, (kz, z), d)) ->
+          Red(Black(a, (kx, x), b), (ky, y), Black(c, (kz, z), d))
+      | l, kx, x, r ->
+          Black(l, (kx, x), r)
+
+  let add kx x m =
+    let rec add_aux = function
+      | Empty ->
+          Red(Empty, (kx, x), Empty)
+      | Red(l, (ky, y), r) ->
+          let c = Key.compare kx ky in
+            if c < 0 then
+              Red(add_aux l, (ky, y), r)
+            else if c > 0 then
+              Red(l, (ky, y), add_aux r)
+            else
+              Red(l, (kx, x), r)
+      | Black(l, (ky, y), r) ->
+          let c = Key.compare kx ky in
+            if c < 0 then
+              balance_left (add_aux l) ky y r
+            else if c > 0 then
+              balance_right l ky y (add_aux r)
+            else
+              Black(l, (kx, x), r)
+    in fst (blackify (add_aux m))
+
+  let insert = add
+
+  let from_list l =
+    let f t (k,v) = insert k v t in
+    List.fold_left f empty l
+
+  let rec find k = function
+    | Empty ->
+        raise Not_found
+    | Red(l, (kx, x), r)
+    | Black(l, (kx, x), r) ->
+        let c = Key.compare k kx in
+          if c < 0 then 
+            find k l
+          else if c > 0 then 
+            find k r
+          else x
+
+  let rec modify k f = function
+    | Empty -> Empty
+    | Red(l, (kx, x), r) ->
+       let c = Key.compare k kx in
+       if c < 0 then
+         Red(modify k f l, (kx,x), r)
+       else if c > 0 then
+         Red(l, (kx,x), modify k f r)
+       else
+         Red(l, (kx, f x), r)
+    | Black(l, (kx, x), r) ->
+       let c = Key.compare k kx in
+       if c < 0 then
+         Black(modify k f l, (kx,x), r)
+       else if c > 0 then
+         Black(l, (kx,x), modify k f r)
+       else
+         Black(l, (kx, f x), r)
+
+  let unbalanced_left = function
+    | Red(Black(a, (kx, x), b), (ky, y), c) ->
+        balance_left (Red(a, (kx, x), b)) ky y c, false
+    | Black(Black(a, (kx, x), b), (ky, y), c) ->
+        balance_left (Red(a, (kx, x), b)) ky y c, true
+    | Black(Red(a, (kx, x), Black(b, (ky, y), c)), (kz, z), d) ->
+        Black(a, (kx, x), balance_left (Red(b, (ky, y), c)) kz z d), false
+    | _ ->
+        assert false
+
+  let unbalanced_right = function
+    | Red(a, (kx, x), Black(b, (ky, y), c)) ->
+        balance_right a kx x (Red(b, (ky, y), c)), false
+    | Black(a, (kx, x), Black(b, (ky, y), c)) ->
+        balance_right a kx x (Red(b, (ky, y), c)), true
+    | Black(a, (kx, x), Red(Black(b, (ky, y), c), (kz, z), d)) ->
+        Black(balance_right a kx x (Red(b, (ky, y), c)), (kz, z), d), false
+    | _ ->
+        assert false
+
+  let rec remove_min = function
+    | Empty
+    | Black(Empty, (_, _), Black(_)) ->
+        assert false
+    | Black(Empty, (kx, x), Empty) ->
+        Empty, kx, x, true
+    | Black(Empty, (kx, x), Red(l, (ky, y), r)) ->
+        Black(l, (ky, y), r), kx, x, false
+    | Red(Empty, (kx, x), r) ->
+        r, kx, x, false
+    | Black(l, (kx, x), r) ->
+        let l, ky, y, d = remove_min l in
+        let m = Black(l, (kx, x), r) in
+          if d then
+            let m, d = unbalanced_right m in m, ky, y, d
+          else
+            m, ky, y, false
+    | Red(l, (kx, x), r) ->
+        let l, ky, y, d = remove_min l in
+        let m = Red(l, (kx, x), r) in
+          if d then
+            let m, d = unbalanced_right m in m, ky, y, d
+          else
+            m, ky, y, false
+
+  let remove k m =
+    let rec remove_aux = function
+      | Empty ->
+          Empty, false
+      | Black(l, (kx, x), r) ->
+          let c = Key.compare k kx in
+            if c < 0 then
+              let l, d = remove_aux l in
+              let m = Black(l, (kx, x), r) in
+                if d then unbalanced_right m else m, false
+            else if c > 0 then
+              let r, d = remove_aux r in
+              let m = Black(l, (kx, x), r) in
+                if d then unbalanced_left m else m, false
+            else
+              begin match r with
+                | Empty ->
+                    blackify l
+                | _ ->
+                    let r, kx, x, d = remove_min r in
+                    let m = Black(l, (kx, x), r) in
+                      if d then unbalanced_left m else m, false
+              end
+      | Red(l, (kx, x), r) ->
+          let c = Key.compare k kx in
+            if c < 0 then
+              let l, d = remove_aux l in
+              let m = Red(l, (kx, x), r) in
+                if d then unbalanced_right m else m, false
+            else if c > 0 then
+              let r, d = remove_aux r in
+              let m = Red(l, (kx, x), r) in
+                if d then unbalanced_left m else m, false
+            else
+              begin match r with
+                | Empty ->
+                    l, false
+                | _ ->
+                    let r, kx, x, d = remove_min r in
+                    let m = Red(l, (kx, x), r) in
+                      if d then unbalanced_left m else m, false
+              end
+    in fst (remove_aux m)
+
+  let rec mem k = function
+    | Empty ->
+        false
+    | Red(l, (kx, _), r)
+    | Black(l, (kx, _), r) ->
+        let c = Key.compare k kx in
+          if c < 0 then mem k l
+          else if c > 0 then mem k r
+          else true
+
+  let lookup k t =
+    if mem k t then
+      Some(find k t)
+    else
+      None
+
+  let rec iter f = function
+    | Empty -> ()
+    | Red(l, (k, x), r) | Black(l, (k, x), r) -> iter f l; f k x; iter f r
+
+  let rec map f = function
+    | Empty -> Empty
+    | Red(l, (k, x), r) -> Red(map f l, (k, f x), map f r)
+    | Black(l, (k, x), r) -> Black(map f l, (k, f x), map f r)
+
+  let rec mapi f = function
+    | Empty -> Empty
+    | Red(l, (k, x), r) -> Red(mapi f l, (k, f k x), mapi f r)
+    | Black(l, (k, x), r) -> Black(mapi f l, (k, f k x), mapi f r)
+
+  let rec fold f m accu =
+    match m with
+      | Empty -> accu
+      | Red(l, (k, x), r) | Black(l, (k, x), r) -> fold f r (f k x (fold f l accu))
+
+  let compare cmp m1 m2 =
+    let rec compare_aux e1 e2 =
+      match e1, e2 with
+        | End, End ->
+            0
+        | End, _ ->
+            -1
+        | _, End ->
+            1
+        | More(k1, x1, r1, e1), More(k2, x2, r2, e2) ->
+            let c = Key.compare k1 k2 in
+              if c <> 0 then c
+              else
+                let c = cmp x1 x2 in
+                  if c <> 0 then c
+                  else compare_aux (enum r1 e1) (enum r2 e2)
+    in compare_aux (enum m1 End) (enum m2 End)
+
+  let equal cmp m1 m2 =
+    let rec equal_aux e1 e2 =
+      match e1, e2 with
+        | End, End ->
+            true
+        | End, _
+        | _, End ->
+            false
+        | More(k1, x1, r1, e1), More(k2, x2, r2, e2) ->
+            (Key.compare k1 k2 = 0
+                && cmp x1 x2
+                && equal_aux (enum r1 e1) (enum r2 e2))
+    in equal_aux (enum m1 End) (enum m2 End)
+
+  let rec update sigf updf t = match t with
+    | Empty -> Empty
+    | Red(l, (k, v), r) 
+      when sigf k > 0 -> Red(update sigf updf l, (k, v), r)
+    | Black(l, (k, v), r) 
+      when sigf k > 0 -> Black(update sigf updf l, (k, v), r)
+    | Red(l, (k, v), r) 
+      when sigf k < 0 -> Red(l, (k, v), update sigf updf r)
+    | Black(l, (k, v), r) 
+      when sigf k < 0 -> Black(l, (k, v), update sigf updf r)
+    | Red(l, (k, v), r) 
+      when sigf k = 0 -> Red(update sigf updf l, 
+                             (k, updf v),
+                             update sigf updf r)
+    | Black(l, (k, v), r) 
+      when sigf k = 0 -> Black(update sigf updf l, 
+                               (k, updf v),
+                               update sigf updf r)
+    | _ -> failwith "Rbmap.update.exhaustiveness"
+
+  let rec select sigf t = match t with
+    | Empty -> []
+    | Red(l, (k, _), _) | Black(l, (k, _), _)
+      when sigf k > 0 -> select sigf l
+    | Red(_, (k, _), r) | Black(_, (k, _), r) 
+      when sigf k < 0 -> select sigf r
+    | Red(l, (k, v), r) 
+      when sigf k = 0 -> (select sigf l)@(v::(select sigf r))
+    | Black(l, (k, v), r) 
+      when sigf k = 0 -> (select sigf l)@(v::(select sigf r))
+    | _ -> failwith "Rbmap.select.exhaustiveness"
+
+  let merge lca v1 v2 =
+    let ks = List.sort_uniq (Key.compare) (keys v1 @ keys v2) in
+    let f t k = match (lookup k lca, lookup k v1, lookup k v2) with
+      (* If k is present in all three, do a merge.  I'm assuming that
+         if all are equal, result of merge is also equal *)
+      | (Some(a_lca), Some(a_v1), Some(a_v2)) ->
+         insert k (Value.merge a_lca a_v1 a_v2) t
+      (* If k is dropped by either new version, drop it *)
+      | (Some(_), None, _) -> t
+      | (Some(_), _, None) -> t
+      (* If k is added by either version, keep it.  If added by both,
+         arbitrarily take the v2 value *)
+      | (_, _, Some(a_v2)) -> insert k a_v2 t
+      | (_, Some(a_v1), _) -> insert k a_v1 t
+      | (None,None,None) -> failwith "Rbmap.merge.exhaustiveness"
+    in
+    List.fold_left f empty ks
+end

--- a/src/mrbmap.mli
+++ b/src/mrbmap.mli
@@ -1,0 +1,47 @@
+module Make (Key : Content.ATOM)(Value : Content.TYPE) : sig
+  type t
+  val t : t Irmin.Type.t
+
+  (** The empty map *)
+  val empty : t
+
+  val is_empty : t -> bool
+
+  val from_list : (Key.t * Value.t) list -> t
+
+  val insert : Key.t -> Value.t -> t -> t
+
+  (** Apply the function to the keyed value, if it exists *)
+  val modify : Key.t -> (Value.t -> Value.t) -> t -> t
+
+  val find : Key.t -> t -> Value.t
+
+  val lookup : Key.t -> t -> Value.t option
+
+  val remove : Key.t -> t -> t
+
+  (** Check if a key is in the map *)
+  val mem : Key.t -> t -> bool
+
+  val iter : (Key.t -> Value.t -> unit) -> t -> unit
+
+  val map : (Value.t -> Value.t) -> t -> t
+
+  val mapi : (Key.t -> Value.t -> Value.t) -> t -> t
+
+  val fold : (Key.t -> Value.t -> Value.t -> Value.t) -> t -> Value.t -> Value.t
+
+  val compare : (Value.t -> Value.t -> int) -> t -> t -> int
+
+  val equal : (Value.t -> Value.t -> bool) -> t -> t -> bool
+
+  val update : (Key.t -> int) -> (Value.t -> Value.t) -> t -> t
+
+  val select : (Key.t -> int) -> t -> Value.t list
+
+  val keys : t -> Key.t list
+
+  (** [merge lca v1 v2] performs three-way merge on [v1] and [v2],
+     using [lca] as the common ancestor **)
+  val merge : t -> t -> t -> t
+end

--- a/src/mrdtTests.ml
+++ b/src/mrdtTests.ml
@@ -68,6 +68,9 @@ let mi2 = Map.update (fun _ -> 0) (fun n -> n + 1) mi1
 let () = assert (mi2 =~ Map.from_list [(0,6);(1,3);(5,4);(25,5)])
 let () = assert (Map.lookup 5 mi2 = Some(4))
 let mi3 = Map.modify 5 (fun n -> n + 1) mi2
+let () = assert (mi3 =~ Map.merge mi2 mi3 mi2)
+let mi4 = Map.modify 5 (fun n -> n - 2) mi3
+let () = assert (mi4 =~ Map.modify 5 (fun n -> n - 1) mi2)
 let () = assert (mi3 =~ Map.from_list [(0,6);(1,3);(5,5);(25,5)])
 let () = assert (Map.select (fun _ -> 0) mi3 = [6;3;5;5])
 let () = assert (Map.select (Int.compare 1) mi3 = [3])
@@ -93,3 +96,8 @@ let l3 = List.insert (List.insert l1 1 6) 0 8
 
 let () = assert (List.merge l1 l2 l3 = [8;4;5;6])
 let () = assert (List.merge l1 l3 l2 = [8;4;5;6])
+
+(* Tests for TPCC *)
+
+let i1 = Mtpcc.Id.random
+let () = assert (i1 >= 0L && i1 <= 10000000000L)

--- a/src/mrdtTests.ml
+++ b/src/mrdtTests.ml
@@ -36,6 +36,41 @@ let () = assert (not (Set.subset s4 s12))
 let () = assert (Set.mem 7 s4)
 let () = assert (not (Set.mem 7 s12))
 
+(* Tests for the Rbmap impl of red-black tree maps *)
+module Map = Mrbmap.Make(SInt)(SInt)
+
+(* Check equality of all assocs, ignoring structure/balance differences in the tree representation *)
+let (=~) = Map.equal Int.equal
+
+let m0 = Map.empty
+
+let m1 = Map.insert 2 3 m0
+
+let () = assert (Map.find 2 m1 = 3)
+let () = assert (not (Map.mem 3 m1))
+
+let m1' = Map.insert 3 1 (Map.insert 2 4 m0)
+let m2 = Map.insert 7 2 (Map.insert 2 5 m1)
+let m3 = Map.remove 2 m1
+
+let () = assert (Map.merge m0 m1 m1' = m1')
+let () = assert (Map.merge m0 m1' m1 = Map.insert 3 1 m1)
+let () = assert (Map.merge m1 m1 m2 = m2)
+let () = assert (Map.merge m1 m2 m1 = m2)
+let () = assert (Map.merge m1 m2 m3 = Map.remove 2 m2)
+let () = assert (Map.merge m1 m3 m2 = Map.remove 2 m2)
+
+let mi0 = Map.from_list [(6,1);(0,3)]
+let () = assert (mi0 =~ Map.insert 6 1 (Map.insert 0 3 Map.empty))
+
+let mi1 = Map.from_list [(0,5);(1,2);(5,3);(25,4)]
+let mi2 = Map.update (fun _ -> 0) (fun n -> n + 1) mi1
+let () = assert (mi2 =~ Map.from_list [(0,6);(1,3);(5,4);(25,5)])
+let () = assert (Map.lookup 5 mi2 = Some(4))
+let mi3 = Map.modify 5 (fun n -> n + 1) mi2
+let () = assert (mi3 =~ Map.from_list [(0,6);(1,3);(5,5);(25,5)])
+let () = assert (Map.select (fun _ -> 0) mi3 = [6;3;5;5])
+let () = assert (Map.select (Int.compare 1) mi3 = [3])
 
 (* Tests for Mlist *)
 module List = Mlist.Make(SInt)

--- a/src/mtpcc.ml
+++ b/src/mtpcc.ml
@@ -1,0 +1,732 @@
+module Id = struct 
+  type t = int64
+
+  let t = Irmin.Type.int64
+
+  let to_string : t -> string = 
+    Fmt.to_to_string (Irmin.Type.pp_json t)
+
+  let compare = Int64.compare
+
+  let of_int = Int64.of_int
+
+  let random = Random.int64 10000000000L
+end
+
+type id = Id.t
+let id = Id.t
+
+type item_req =
+  { _ol_num: int32; (* seq no *)
+    _ol_i_id: id; 
+    _ol_supply_w_id: id; _ol_qty: int32
+  }
+
+let minf f l = 
+  List.fold_left 
+    (fun acc x -> match acc with
+       | None -> Some x
+       | Some x' -> if Int64.compare (f x) (f x') < 0 
+                  then Some x else acc)
+    None l
+
+module Warehouse = struct
+  type t = { w_id: Id.t; w_ytd: int32 }
+  [@@deriving irmin]
+
+  let merge lca {w_ytd=y1; _} {w_ytd=y2; _} =  
+    {lca with w_ytd = SInt32.merge lca.w_ytd y1 y2}
+
+  (* This boiler-plate implements the Content.TYPE signature so that
+     Warehouse, District, etc. can be used as values in Mrbmap *)
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module District = struct 
+  type t = { d_w_id: Id.t; d_id: Id.t; d_ytd: int32 }
+  [@@deriving irmin]
+
+  let merge lca {d_ytd=y1; _} {d_ytd=y2; _} =  
+    {lca with d_ytd = SInt32.merge lca.d_ytd y1 y2}
+
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module Order = struct
+  type t =
+    { o_w_id: Id.t;
+      o_d_id: Id.t;
+      o_id: Id.t;
+      o_c_id: Id.t; 
+      o_ol_cnt: int32; 
+      o_carrier_id: bool
+    }
+  [@@deriving irmin]
+
+  let merge lca ({o_carrier_id=b1; _} as v1) 
+                ({o_carrier_id=b2; _} as v2) =  
+    if lca.o_carrier_id = true
+    then (assert (lca=v1 && v1=v2); lca)
+    else {lca with o_carrier_id = b1 || b2}
+
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module NewOrder = struct 
+  type t = {no_w_id: Id.t; no_d_id: Id.t; no_o_id: Id.t}
+  [@@deriving irmin]
+
+  let merge _ _ _ = failwith "new_order is immutable"
+
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module OrderLine = struct 
+  type t =
+    { ol_w_id: Id.t;
+      ol_d_id: Id.t; 
+      ol_o_id: Id.t;
+      ol_i_id: Id.t;
+      ol_num: int32; 
+      ol_supply_w_id: Id.t;
+      ol_amt: int32;
+      ol_qty: int32;
+      ol_delivery_d: float option
+    }
+  [@@deriving irmin]
+
+  let merge lca {ol_delivery_d=d1; _} {ol_delivery_d=d2; _} = 
+    let d = match d1,d2 with 
+      | None,None -> None 
+      | Some d1,None -> Some d1 
+      | None,Some d2 -> Some d2
+      | Some d1, Some d2 -> Some (min d1 d2) in
+    {lca with ol_delivery_d=d}
+
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module Item = struct
+  type t = {i_id: Id.t; i_name: string; i_price: int32}
+  [@@deriving irmin]
+
+  let merge _ _ _ = failwith "Item is immutable"
+
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module Hist = struct 
+  type t =
+    { h_c_id: Id.t;
+      h_c_d_id: Id.t;
+      h_c_w_id: Id.t; 
+      h_d_id: Id.t;
+      h_w_id: Id.t;
+      h_amt: int32
+    }
+  [@@deriving irmin]
+
+  let merge _ _ _ = failwith "Hist is immutable"
+
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module Stock = struct 
+  type t =
+    { s_w_id: Id.t;
+      s_i_id: Id.t;
+      s_qty: int32; 
+      s_ytd: int32;
+      s_order_cnt: int32
+    }
+  [@@deriving irmin]
+
+  let merge
+        {s_i_id; s_w_id; s_qty=q; 
+         s_ytd=y; s_order_cnt=c; _}
+
+        {s_qty=q1; s_ytd=y1; s_order_cnt=c1; _}
+
+        {s_qty=q2; s_ytd=y2; s_order_cnt=c2; _} =
+
+    let q' = SInt32.merge q q1 q2 in
+    let y' = SInt32.merge y y1 y2 in
+    let c' = SInt32.merge c c1 c2 in
+    {s_i_id; s_w_id; s_qty=q'; s_ytd=y'; s_order_cnt=c'}
+
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module Customer = struct
+  type t =
+    { c_w_id: Id.t;
+      c_d_id: Id.t;
+      c_id: Id.t; 
+      c_bal: int32; 
+      c_ytd_payment: int32; 
+      c_payment_cnt: int32; 
+      c_delivery_cnt: int32
+    }
+  [@@deriving irmin]
+
+  (* Due to delivery txn, customer merge is non-trivial. We shall do
+   * real merging of customer at the DB level. Following is called
+   * from the db level merge function.*)
+
+  let merge
+        {c_id; c_d_id; c_w_id; c_bal=b; 
+         c_ytd_payment=y; c_payment_cnt=p;
+         c_delivery_cnt=d; _} 
+
+        {c_bal=b1; c_ytd_payment=y1; 
+         c_payment_cnt=p1; c_delivery_cnt=d1; _}
+
+        {c_bal=b2; c_ytd_payment=y2; 
+         c_payment_cnt=p2; c_delivery_cnt=d2; _} =
+
+    let b' = SInt32.merge b b1 b2 in
+    let y' = SInt32.merge y y1 y2 in
+    let p' = SInt32.merge p p1 p2 in
+    let d' = SInt32.merge d d1 d2 in
+    {c_id; c_d_id; c_w_id; c_bal=b'; c_ytd_payment=y';
+     c_payment_cnt=p'; c_delivery_cnt=d'}
+
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module IdPair = struct 
+  type t = Id.t * Id.t
+  [@@deriving irmin]
+
+  let t = let open Irmin.Type in pair id id
+
+  let to_string : t -> string = 
+    Fmt.to_to_string (Irmin.Type.pp_json t)
+
+  let compare (x1,y1) (x2,y2) = 
+    match Id.compare x1 x2, Id.compare y1 y2 with
+      | 0, v2 -> v2
+      | v1, _ -> v1
+end
+
+module IdTriple = struct
+  type t = Id.t * (Id.t * Id.t)
+  [@@deriving irmin]
+
+  let t = let open Irmin.Type in pair id (pair id id)
+
+  let to_string : t -> string =
+    Fmt.to_to_string (Irmin.Type.pp_json t)
+
+  let compare (x1,(y1,z1)) (x2,(y2,z2)) =
+    match Id.compare x1 x2, Id.compare y1 y2, Id.compare z1 z2 with
+      | 0, 0, v3 -> v3
+      | 0, v2, _ -> v2
+      | v1, _, _ -> v1
+end
+
+module IdQuad = struct
+  type t = Id.t * (Id.t * (Id.t * Id.t))
+  [@@deriving irmin]
+
+  let t = let open Irmin.Type in pair id (pair id (pair id id))
+
+  let to_string : t -> string =
+    Fmt.to_to_string (Irmin.Type.pp_json t)
+
+  let compare (w1,(x1,(y1,z1))) (w2,(x2,(y2,z2))) =
+    match Id.compare w1 w2, Id.compare x1 x2,
+          Id.compare y1 y2, Id.compare z1 z2 with
+      | 0, 0, 0, v4 -> v4
+      | 0, 0, v3, _ -> v3
+      | 0, v2, _, _ -> v2
+      | v1, _, _, _ -> v1
+end
+
+module IdQuin = struct
+  type t = Id.t * (Id.t * ( Id.t * (Id.t * Id.t)))
+  [@@deriving irmin]
+
+  let t = let open Irmin.Type in
+    (pair id (pair id (pair id (pair id id))))
+
+  let to_string : t -> string =
+    Fmt.to_to_string (Irmin.Type.pp_json t)
+
+  let compare (u1,(w1,(x1,(y1,z1)))) (u2, (w2,(x2,(y2,z2)))) =
+    match Id.compare u1 u2, Id.compare w1 w2, Id.compare x1 x2,
+          Id.compare y1 y2, Id.compare z1 z2 with
+      | 0, 0, 0, 0, v5 -> v5
+      | 0, 0, 0, v4, _ -> v4
+      | 0, 0, v3, _, _ -> v3
+      | 0, v2, _, _, _ -> v2
+      | v1, _, _, _, _ -> v1
+end
+
+module WarehouseTable = Mrbmap.Make(Id)(Warehouse)
+
+module DistrictTable = Mrbmap.Make(IdPair)(District)
+
+module OrderTable = Mrbmap.Make(IdTriple)(Order)
+
+module NewOrderTable = Mrbmap.Make(IdTriple)(NewOrder)
+
+module OrderLineTable = Mrbmap.Make(IdQuad)(OrderLine)
+
+module ItemTable = Mrbmap.Make(Id)(Item)
+
+module HistTable = Mrbmap.Make(IdQuin)(Hist)
+
+module StockTable = Mrbmap.Make(IdPair)(Stock)
+
+module CustomerTable = Mrbmap.Make(IdTriple)(Customer)
+
+type db =
+  { warehouse_table: WarehouseTable.t;
+    district_table: DistrictTable.t;
+    order_table: OrderTable.t;
+    neworder_table: NewOrderTable.t;
+    orderline_table: OrderLineTable.t;
+    item_table: ItemTable.t;
+    hist_table: HistTable.t;
+    stock_table: StockTable.t;
+    customer_table: CustomerTable.t
+  }
+[@@deriving irmin]
+
+module Db = struct
+  type t = db
+  let t = db_t
+
+  let merge lca v1 v2 =
+    { warehouse_table = WarehouseTable.merge
+                          lca.warehouse_table
+                          v1.warehouse_table
+                          v2.warehouse_table
+    ; district_table = DistrictTable.merge
+                          lca.district_table
+                          v1.district_table
+                          v2.district_table
+    ; order_table = OrderTable.merge
+                          lca.order_table
+                          v1.order_table
+                          v2.order_table
+    ; neworder_table = NewOrderTable.merge
+                          lca.neworder_table
+                          v1.neworder_table
+                          v2.neworder_table
+    ; orderline_table = OrderLineTable.merge
+                          lca.orderline_table
+                          v1.orderline_table
+                          v2.orderline_table
+    ; item_table = ItemTable.merge
+                          lca.item_table
+                          v1.item_table
+                          v2.item_table
+    ; hist_table = HistTable.merge
+                          lca.hist_table
+                          v1.hist_table
+                          v2.hist_table
+    ; stock_table = StockTable.merge
+                          lca.stock_table
+                          v1.stock_table
+                          v2.stock_table
+    ; customer_table = CustomerTable.merge
+                          lca.customer_table
+                          v1.customer_table
+                          v2.customer_table
+    }
+
+  type o = t
+  let o_merge = merge
+  let to_adt t = t
+  let of_adt t = t
+end
+
+module Txn = struct
+  type 'a t = db -> 'a * db
+
+  let bind m f = fun db ->
+    let (a,db') = m db in
+    f a db'
+
+  let return a = fun db -> (a,db)
+end
+
+module Insert = struct
+  let order_table o db = 
+    let open Order in
+    let t = db.order_table in
+    let t'= OrderTable.insert (o.o_w_id, (o.o_d_id, o.o_id)) o t in
+        ((),{db with order_table=t'})
+
+  let neworder_table no db = 
+    let open NewOrder in
+    let t = db.neworder_table in
+    let t'= NewOrderTable.insert 
+              (no.no_w_id, (no.no_d_id, no.no_o_id)) no t in
+        ((),{db with neworder_table=t'})
+
+  let orderline_table r db = 
+    let open OrderLine in
+    let t = db.orderline_table in
+    let t' = OrderLineTable.insert
+       (r.ol_w_id, (r.ol_d_id, (r.ol_o_id, r.ol_i_id))) r t in
+    ((),{db with orderline_table=t'})
+
+  let hist_table r db = 
+    let open Hist in
+    let t = db.hist_table in
+    let t' = HistTable.insert
+       (r.h_w_id, (r.h_d_id, (r.h_c_w_id, (r.h_c_d_id, r.h_c_id)))) r t in
+    ((),{db with hist_table=t'})
+
+  let item_table o db = 
+    let open Item in
+    let t = db.item_table in
+    let t'= ItemTable.insert (o.i_id) o t in
+        ((),{db with item_table=t'})
+
+  let warehouse_table o db = 
+    let open Warehouse in
+    let t = db.warehouse_table in
+    let t'= WarehouseTable.insert (o.w_id) o t in
+        ((),{db with warehouse_table=t'})
+
+  let district_table o db = 
+    let open District in
+    let t = db.district_table in
+    let t'= DistrictTable.insert (o.d_w_id, o.d_id) o t in
+        ((),{db with district_table=t'})
+
+  let customer_table o db = 
+    let open Customer in
+    let t = db.customer_table in
+    let t'= CustomerTable.insert (o.c_w_id, (o.c_d_id, o.c_id)) o t in
+        ((),{db with customer_table=t'})
+
+  let stock_table o db = 
+    let open Stock in
+    let t = db.stock_table in
+    let t'= StockTable.insert (o.s_w_id, o.s_i_id) o t in
+        ((),{db with stock_table=t'})
+end
+
+module Update = struct 
+  let warehouse_table sigf updf db = 
+    let t = db.warehouse_table in
+    let t' = WarehouseTable.update sigf updf t in
+    ((), {db with warehouse_table=t'})
+
+  let district_table sigf updf db = 
+    let t = db.district_table in
+    let t' = DistrictTable.update sigf updf t in
+    ((), {db with district_table=t'})
+
+  let order_table sigf updf db = 
+    let t = db.order_table in
+    let t' = OrderTable.update sigf updf t in
+    ((), {db with order_table=t'})
+
+  let orderline_table sigf updf db = 
+    let t = db.orderline_table in
+    let t' = OrderLineTable.update sigf updf t in
+    ((), {db with orderline_table=t'})
+
+  let stock_table sigf updf db = 
+    let t = db.stock_table in
+    let t' = StockTable.update sigf updf t in
+    ((), {db with stock_table=t'})
+
+  let customer_table sigf updf db = 
+    let t = db.customer_table in
+    let t' = CustomerTable.update sigf updf t in
+    ((), {db with customer_table=t'})
+end
+
+module Delete = struct
+  let neworder_table (no_w_id, no_d_id, no_o_id) db =
+    let t = db.neworder_table in
+    let t' = NewOrderTable.remove (no_w_id, (no_d_id,no_o_id)) t in
+    ((), {db with neworder_table=t'})
+end
+
+module Select1 = struct
+  open Printf
+
+  let warehouse_table x db =
+    try
+      let t = db.warehouse_table in
+      let res = WarehouseTable.find x t in
+      (res, db)
+    with Not_found ->
+      failwith @@ sprintf "Warehouse<%s> not found"
+        (Id.to_string x)
+
+  let district_table (x,y) db =
+    try
+      let t = db.district_table in
+      let res = DistrictTable.find (x,y) t in
+      (res, db)
+    with Not_found ->
+      failwith @@ sprintf "District<%s> not found"
+        (IdPair.to_string (x,y))
+
+  let item_table x db =
+    try
+      let t = db.item_table in
+      let res = ItemTable.find x t in
+      (res, db)
+    with Not_found ->
+      failwith @@ sprintf "Item<%s> not found"
+        (Id.to_string x)
+
+  let order_table (x,y,z) db =
+    try
+      let t = db.order_table in
+      let res = OrderTable.find (x,(y,z)) t in
+      (res, db)
+    with Not_found ->
+      failwith @@ sprintf "Order<%s> not found"
+        (IdTriple.to_string (x,(y,z)))
+
+  let stock_table (x,y) db =
+    try
+      let t = db.stock_table in
+      let res = StockTable.find (x,y) t in
+      (res, db)
+    with Not_found ->
+      failwith @@ sprintf "Stock<%s> not found"
+        (IdPair.to_string (x,y))
+
+  let customer_table (x,y,z) db =
+    try
+      let t = db.customer_table in
+      let res = CustomerTable.find (x,(y,z)) t in
+      (res, db)
+    with Not_found ->
+      failwith @@ sprintf "Customer<%s> not found"
+        (IdTriple.to_string (x,(y,z)))
+end
+
+module Select = struct
+  let warehouse_table sigf db =
+    let t = db.warehouse_table in
+    let res = WarehouseTable.select sigf t in
+    (res, db)
+
+  let district_table sigf db =
+    let t = db.district_table in
+    let res = DistrictTable.select sigf t in
+    (res, db)
+
+  let item_table sigf db =
+    let t = db.item_table in
+    let res = ItemTable.select sigf t in
+    (res, db)
+
+  let order_table sigf db =
+    let t = db.order_table in
+    let res = OrderTable.select sigf t in
+    (res, db)
+
+  let orderline_table sigf db =
+    let t = db.orderline_table in
+    let res = OrderLineTable.select sigf t in
+    (res, db)
+
+  let neworder_table sigf db =
+    let t = db.neworder_table in
+    let res = NewOrderTable.select sigf t in
+    (res, db)
+
+  let stock_table sigf db =
+    let t = db.stock_table in
+    let res = StockTable.select sigf t in
+    (res, db)
+
+  let customer_table sigf db =
+    let t = db.customer_table in
+    let res = CustomerTable.select sigf t in
+    (res, db)
+
+  let hist_table sigf db =
+    let t = db.hist_table in
+    let res = HistTable.select sigf t in
+    (res, db)
+end
+
+module App = struct
+  let (+) = Int32.add
+  let (-) = Int32.add
+  let ( * ) = Int32.mul
+  let (>>=) = Txn.bind
+
+  open Warehouse
+  open District
+  open Order
+  open NewOrder
+  open OrderLine
+  open Item
+  open Stock
+  open Customer
+  open Hist
+
+  open Printf
+
+  let dump_stock_keys db = 
+    let fp = open_out "stock_keys.db" in
+    let dump2 k _ = 
+      fprintf fp "%s\n" @@ IdPair.to_string k in
+    begin 
+      fprintf fp "\n> Stock\n";
+      StockTable.iter dump2 db.stock_table;
+      close_out fp;
+      printf "Dumped keys in stock_keys.db\n";
+      ((),db)
+    end
+
+  let new_order_txn w_id d_id c_id (ireqs: item_req list) : unit Txn.t  =
+    let _ = printf "new_order_txn\n" in
+    let _ = flush_all () in
+    let o_id = Random.int64 10000000000L in
+    let ord = let open Order in
+              {o_id=o_id; o_w_id=w_id; 
+               o_d_id=d_id; o_c_id=c_id; 
+               o_ol_cnt=Int32.of_int @@ List.length ireqs; 
+               o_carrier_id =false} in
+    let new_ord = let open NewOrder in
+                  {no_o_id=o_id; no_w_id=w_id; no_d_id=d_id} in
+    Insert.order_table ord >>= fun _ ->
+    Insert.neworder_table new_ord >>= fun _ ->
+    List.fold_left
+      (fun pre ireq -> 
+         pre>>= fun () ->
+         (*dump_stock_keys >>= fun () ->*)
+         Select1.stock_table (ireq._ol_supply_w_id, 
+                              ireq._ol_i_id) >>= fun stk ->
+         Select1.item_table ireq._ol_i_id >>= fun item ->
+         let ol = {ol_o_id=o_id; ol_d_id=d_id; ol_w_id=w_id; 
+                   ol_num=ireq._ol_num; ol_i_id=ireq._ol_i_id; 
+                   ol_supply_w_id=ireq._ol_supply_w_id; 
+                   ol_amt=item.i_price * ireq._ol_qty;
+                   ol_qty=ireq._ol_qty; ol_delivery_d=None} in
+         let s_qty = if Int32.compare stk.s_qty 
+                         (ireq._ol_qty + 10l) >= 0
+                     then stk.s_qty - ireq._ol_qty
+                     else stk.s_qty - ireq._ol_qty + 91l in
+         Update.stock_table 
+             (fun stock_key -> IdPair.compare stock_key
+                   (ireq._ol_supply_w_id, ireq._ol_i_id))
+             (fun s -> 
+                { s with
+                  s_qty = s_qty;
+                  s_ytd = stk.s_ytd + ireq._ol_qty; 
+                  s_order_cnt = stk.s_order_cnt + 1l}) >>= fun () ->
+          Insert.orderline_table ol) 
+      (Txn.return ())
+      ireqs
+
+  let payment_txn w_id d_id c_id h_amt = 
+    let _ = printf "payment_txn\n" in
+    let _ = flush_all () in
+    let d_w_id = w_id in
+    let c_w_id = w_id in
+    let c_d_id = d_id in
+    Select1.warehouse_table (w_id) >>= fun _ ->
+    Select1.district_table (d_w_id, d_id) >>= fun _ ->
+    Select1.customer_table (c_w_id, c_d_id, c_id) >>= fun _ ->
+    let h_item = {h_c_id = c_id; h_c_d_id = c_d_id; h_c_w_id = c_w_id; 
+                  h_d_id = d_id; h_w_id = w_id; h_amt = h_amt} in
+    Update.warehouse_table
+        (fun wh_id -> Id.compare wh_id w_id)
+        (fun wh -> {wh with w_ytd = wh.w_ytd + h_amt}) >>= fun () ->
+    Update.district_table
+      (fun dist_key -> 
+         IdPair.compare dist_key (d_w_id,d_id))
+      (fun dist -> {dist with 
+                      d_ytd = dist.d_ytd + h_amt}) >>= fun () ->
+    Update.customer_table
+      (fun ckey -> IdTriple.compare ckey
+                    (c_w_id, (c_d_id, c_id)))
+      (fun c -> 
+         {c with c_bal = c.c_bal - h_amt;
+                 c_ytd_payment = c.c_ytd_payment + h_amt;
+                 c_payment_cnt = c.c_payment_cnt + 1l}) >>= fun () ->
+    Insert.hist_table h_item
+  
+  let delivery_txn w_id =
+    let _ = printf "delivery_txn\n" in
+    let _ = flush_all () in
+    Select.district_table 
+      (fun (dist_w_id,_) -> 
+         Id.compare dist_w_id w_id) >>= fun dists ->
+    List.fold_left 
+      (fun pre d -> 
+         pre >>= fun () ->
+         Select.neworder_table
+           (fun (no_w_id, (no_d_id,_)) -> 
+              IdPair.compare 
+                (no_w_id, no_d_id) (w_id, d.d_id)) >>= fun nords ->
+         let nop = minf (fun no -> no.no_o_id) nords in
+         match nop with 
+           | Some no ->
+             begin 
+               (* delete the no entry *)
+               Delete.neworder_table
+                 (no.no_w_id, no.no_d_id, no.no_o_id) >>= fun () ->
+               Select1.order_table (w_id, d.d_id, no.no_o_id) >>= fun o ->
+               Update.order_table
+                 (fun okey -> IdTriple.compare okey
+                                 (w_id, (d.d_id, no.no_o_id))) 
+                 (fun o -> {o with o_carrier_id = true}) >>= fun () ->
+               Update.orderline_table
+                 (fun (k_w_id, (k_d_id, (k_o_id, _))) -> 
+                    IdTriple.compare (k_w_id, (k_d_id, k_o_id)) 
+                            (o.o_w_id, (o.o_d_id, o.o_id)))
+                 (fun ol -> 
+                    {ol with ol_delivery_d = 
+                               Some (Unix.time ())}) >>= fun () ->
+               Select.orderline_table
+                (fun (k_w_id, (k_d_id, (k_o_id, _))) -> 
+                    IdTriple.compare (k_w_id, (k_d_id, k_o_id)) 
+                            (o.o_w_id, (o.o_d_id, o.o_id))) >>= fun ols ->
+               let amt = List.fold_left (fun acc ol -> 
+                                          acc + ol.ol_amt) 0l ols in
+               Update.customer_table
+                (fun ckey -> IdTriple.compare ckey
+                                (w_id, (d.d_id, o.o_c_id)))
+                (fun c -> 
+                   {c with c_bal = c.c_bal + amt;
+                           c_delivery_cnt = c.c_delivery_cnt + 1l})
+             end
+           | None -> Txn.return ()) 
+      (Txn.return ()) dists
+end

--- a/src/sInt.ml
+++ b/src/sInt.ml
@@ -1,6 +1,13 @@
-
 type t = int
+
+type o = t
 
 let t = Irmin.Type.int
 
 let compare = Int.compare
+
+let merge lca v1 v2 = lca + (v1 - lca) + (v2 - lca)
+
+let to_adt t = t
+let of_adt t = t
+let o_merge = merge

--- a/src/sInt32.ml
+++ b/src/sInt32.ml
@@ -1,0 +1,16 @@
+type t = int32
+
+type o = t
+
+let t = Irmin.Type.int32
+
+let compare = Int32.compare
+
+let merge lca v1 v2 =
+  let (+) = Int32.add in
+  let (-) = Int32.sub in
+  lca + (v1 - lca) + (v2 - lca)
+
+let to_adt t = t
+let of_adt t = t
+let o_merge = merge


### PR DESCRIPTION
Again, few changes from the ocaml-irmin repo versions.

Rbmap is split between `mrbmap.ml` and `irbmap.ml`, where `irbmap.ml` is just a stub since there is no distinct DB representation.

TPCC is all in `mtpcc.ml`. This includes the the `o_merge`, `of_adt`, etc. stubs because I had to define those for each component of the state (`Warehouse`, `Item`, etc.) in order to define them for the whole state. I added a `merge` function for the whole-application `db` state, which applies the merges of all the tables together.
